### PR TITLE
Add rule to Ignore tags

### DIFF
--- a/.tflint.d/policies/003-require-ignore-tags.rego
+++ b/.tflint.d/policies/003-require-ignore-tags.rego
@@ -1,0 +1,27 @@
+package tflint
+
+import rego.v1
+
+deny_require_lifecycle_ignore_tags contains issue if {
+  res := terraform.resources("*",{"lifecycle": {"ignore_changes": "expr"}},{"expand_mode": "none"},)[_]
+
+  res.config.lifecycle[_]
+
+  not has_tags_ignore(res)
+
+  issue := tflint.issue(
+    sprintf(
+      "Resource %s.%s must include \"tags\" in lifecycle.ignore_changes",
+      [res.type, res.name],
+    ),
+    res.decl_range,
+  )
+}
+
+has_tags_ignore(res) if {
+  lifeblock := res.config.lifecycle[_]
+  ic        := lifeblock.config.ignore_changes
+
+  some i
+  trim(hcl.expr_list(ic)[i].value, "\"") == "tags"
+}

--- a/.tflint.d/policies/tests/003-require-ignore-tags_test.rego
+++ b/.tflint.d/policies/tests/003-require-ignore-tags_test.rego
@@ -1,0 +1,76 @@
+package tflint
+
+import rego.v1
+
+failed_lifecycle_ignore_tags(type, _, _) := terraform.mock_resources(type,{"lifecycle": {"ignore_changes": "expr"}},{"expand_mode": "none"},{
+    "main.tf": `
+      resource "aws_instance" "bad" {
+        lifecycle {
+          ignore_changes = ["foo", "bar"]
+        }
+      }
+    `}
+)
+
+passing_lifecycle_ignore_tags(type, _, _) := terraform.mock_resources(type,{"lifecycle": {"ignore_changes": "expr"}},{"expand_mode": "none"},{
+    "main.tf": `
+      resource "aws_instance" "good" {
+        lifecycle {
+          ignore_changes = ["foo", "tags", "bar"]
+        }
+      }
+    `}
+)
+
+dynamic_lifecycle_ignore_tags(type, _, _) := terraform.mock_resources(type,{"lifecycle": {"ignore_changes": "expr"}},{"expand_mode": "none"},{
+    "main.tf": `
+      resource "aws_instance" "also_good" {
+        lifecycle {
+          ignore_changes = [foo_key, tags, var.other]
+        }
+      }
+    `}
+)
+
+no_lifecycle(type, _, _) := terraform.mock_resources(type,{"lifecycle": {"ignore_changes": "expr"}},{"expand_mode": "none"},{
+    "main.tf": `
+      resource "aws_instance" "none" {
+        # no lifecycle block
+        tags = { Environment = "dev" }
+      }
+    `}
+)
+
+
+test_require_lifecycle_ignore_tags_failed if {
+  issues := [ i |
+    i = deny_require_lifecycle_ignore_tags[_]
+      with terraform.resources as failed_lifecycle_ignore_tags
+  ]
+  count(issues) == 1
+  issues[0].msg == "Resource aws_instance.bad must include \"tags\" in lifecycle.ignore_changes"
+}
+
+test_require_lifecycle_ignore_tags_pass_literal if {
+  issues := [ i |
+    i = deny_require_lifecycle_ignore_tags[_]
+      with terraform.resources as passing_lifecycle_ignore_tags
+  ]
+  count(issues) == 0
+}
+
+test_require_lifecycle_ignore_tags_pass_dynamic if {
+  issues := [ i |
+    i = deny_require_lifecycle_ignore_tags[_]
+      with terraform.resources as dynamic_lifecycle_ignore_tags
+  ]
+  count(issues) == 0
+}
+
+test_require_lifecycle_ignore_tags_no_lifecycle if {
+  issues := [ i |
+    i = deny_require_lifecycle_ignore_tags[_]
+      with terraform.resources as no_lifecycle
+  ]
+  count(issues) == 0
+}

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -6,7 +6,7 @@ plugin "azurerm" {
 
 plugin "opa" {
   enabled = true
-  version = "0.8.0"
+  version = "0.9.0"
   source  = "github.com/terraform-linters/tflint-ruleset-opa"
 }
 


### PR DESCRIPTION
This rule ensures that all terraform resources are ignore tags 

```
  lifecycle {
    ignore_changes = [tags]
  }
```
  
  Tags are used and set by azure for subscription and resource mgmt